### PR TITLE
sitemap.xml in README & no RedirectorPage with RedirectionType External

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ By default the module will check for a sitemap file in `/sitemap.xml`. You can s
 
 ```yaml
 gorriecoe\Robots\Robots:
-  sitemap: '/sitemap_index.xml'
+  sitemap: '/sitemap.xml'
 ```
 For multiple sitemaps.
 ```yaml

--- a/src/RobotsSitetree.php
+++ b/src/RobotsSitetree.php
@@ -19,8 +19,8 @@ class RobotsSitetree extends DataExtension
         if (Robots::config()->disallow_unsearchable) {
             foreach (SiteTree::get()->filter('ShowInSearch', false) as $page) {
                 $link = $page->Link();
-                // Don't disallow home page
-                if ($link !== '/') {
+				// Don't disallow home page, no RedirectorPage with RedirectionType External
+				if ($link !== '/' && $page->RedirectionType != 'External') {
                     $urls[] = $link;
                 }
             }


### PR DESCRIPTION
sitemap.xml seems more standard cos of wilr/silverstripe-googlesitemaps & RedirectorPage with RedirectionType External shouldn't go into robots.txt